### PR TITLE
Uncommented matplotlib.use('Agg')

### DIFF
--- a/poretools/hist.py
+++ b/poretools/hist.py
@@ -2,7 +2,7 @@ import sys
 import time
 
 import matplotlib
-#matplotlib.use('Agg') # Must be called before any other matplotlib calls
+matplotlib.use('Agg') # Must be called before any other matplotlib calls
 from matplotlib import pyplot as plt
 
 import seaborn as sns


### PR DESCRIPTION
Uncommented matplotlib.use('Agg') to avoid DISPLAY error during docker container execution.