### PR TITLE
Uncommented matplotlib.use('Agg')

### DIFF
--- a/poretools/yield_plot.py
+++ b/poretools/yield_plot.py
@@ -1,6 +1,6 @@
 import Fast5File
 import matplotlib
-#matplotlib.use('Agg') # Must be called before any other matplotlib calls
+matplotlib.use('Agg') # Must be called before any other matplotlib calls
 from matplotlib import pyplot as plt
 
 import numpy as np


### PR DESCRIPTION
Uncommented matplotlib.use('Agg') to avoid DISPLAY error during docker container execution.